### PR TITLE
 Avoid unsafe use of `char::from_u32_unchecked`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,18 +24,6 @@
 //! [`OsStringBytes::from_bytes`], but the latter should be used when only a
 //! slice is available.
 //!
-//! # Safety
-//!
-//! A moderately unsafe assumption is made that invalid characters created by
-//! [`char::from_u32_unchecked`] are partially usable. The alternative would be
-//! to always encode and decode strings manually, which would be more
-//! dangerous, as it would create a reliance on how the standard library
-//! encodes invalid UTF-8 strings.
-//!
-//! The standard library [makes the same assumption][assumption], since there
-//! are no methods on [`u32`] for encoding. Tests exist to validate the
-//! implementation in this crate.
-//!
 //! # Related Crates
 //!
 //! - [print_bytes] -

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -42,24 +42,24 @@ fn len_wtf8(code: u32) -> usize {
 // From Rust's libcore/char/methods.rs (char::encode_utf8)
 fn encode_wtf8(code: u32, dst: &mut [u8]) -> &mut [u8] {
     let len = len_wtf8(code);
-    match (len, &mut dst[..]) {
-        (1, [a, ..]) => {
-            *a = code as u8;
+    match len {
+        1 => {
+            dst[0] = code as u8;
         }
-        (2, [a, b, ..]) => {
-            *a = (code >> 6 & 0x1F) as u8 | TAG_TWO_B;
-            *b = (code & 0x3F) as u8 | TAG_CONT;
+        2 => {
+            dst[0] = (code >> 6 & 0x1F) as u8 | TAG_TWO_B;
+            dst[1] = (code & 0x3F) as u8 | TAG_CONT;
         }
-        (3, [a, b, c, ..]) => {
-            *a = (code >> 12 & 0x0F) as u8 | TAG_THREE_B;
-            *b = (code >> 6 & 0x3F) as u8 | TAG_CONT;
-            *c = (code & 0x3F) as u8 | TAG_CONT;
+        3 => {
+            dst[0] = (code >> 12 & 0x0F) as u8 | TAG_THREE_B;
+            dst[1] = (code >> 6 & 0x3F) as u8 | TAG_CONT;
+            dst[2] = (code & 0x3F) as u8 | TAG_CONT;
         }
-        (4, [a, b, c, d, ..]) => {
-            *a = (code >> 18 & 0x07) as u8 | TAG_FOUR_B;
-            *b = (code >> 12 & 0x3F) as u8 | TAG_CONT;
-            *c = (code >> 6 & 0x3F) as u8 | TAG_CONT;
-            *d = (code & 0x3F) as u8 | TAG_CONT;
+        4 => {
+            dst[0] = (code >> 18 & 0x07) as u8 | TAG_FOUR_B;
+            dst[1] = (code >> 12 & 0x3F) as u8 | TAG_CONT;
+            dst[2] = (code >> 6 & 0x3F) as u8 | TAG_CONT;
+            dst[3] = (code & 0x3F) as u8 | TAG_CONT;
         }
         _ => unreachable!(),
     };

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -17,7 +17,7 @@ use crate::OsStringBytes;
 #[allow(clippy::module_inception)]
 mod imp;
 
-fn decode_utf16<TString>(encoded_string: TString, length: usize) -> Vec<u8>
+fn wide_to_wtf8<TString>(encoded_string: TString, length: usize) -> Vec<u8>
 where
     TString: IntoIterator<Item = u16>,
 {
@@ -40,7 +40,7 @@ where
     string
 }
 
-fn encode_utf16(string: &[u8]) -> Vec<u16> {
+fn wtf8_to_wide(string: &[u8]) -> Vec<u16> {
     // https://github.com/rust-lang/rust/blob/49c68bd53f90e375bfb3cbba8c1c67a9e0adb9c0/src/libstd/sys_common/wtf8.rs#L797-L813
 
     let mut string = string.iter();
@@ -69,7 +69,7 @@ impl OsStrBytes for OsStr {
 
     #[inline]
     fn to_bytes(&self) -> Cow<'_, [u8]> {
-        Cow::Owned(decode_utf16(OsStrExt::encode_wide(self), self.len()))
+        Cow::Owned(wide_to_wtf8(OsStrExt::encode_wide(self), self.len()))
     }
 }
 
@@ -81,8 +81,8 @@ impl OsStringBytes for OsString {
         TString: AsRef<[u8]>,
     {
         let string = string.as_ref();
-        let encoded_string = encode_utf16(string);
-        if decode_utf16(encoded_string.iter().map(|&x| x), string.len())
+        let encoded_string = wtf8_to_wide(string);
+        if wide_to_wtf8(encoded_string.iter().map(|&x| x), string.len())
             == string
         {
             Ok(OsStringExt::from_wide(&encoded_string))
@@ -96,7 +96,7 @@ impl OsStringBytes for OsString {
     where
         TString: AsRef<[u8]>,
     {
-        OsStringExt::from_wide(&encode_utf16(string.as_ref()))
+        OsStringExt::from_wide(&wtf8_to_wide(string.as_ref()))
     }
 
     #[inline]


### PR DESCRIPTION
The way this function is being used is directly violating its safety clause. Just because the standard library does it internally, it does not mean that it safe do it in non-standard crates.

That behavior is not documented and may change at any moment (which includes crashing or producing a different result).

The current implementations of `encode_utf8` and `encode_utf16` have been copied from Rust's libcore, changing the parameter type from `char` to `u32`.

