### PR TITLE
Add support for SGX (using the x86_64-fortanix-unknown-sgx target)

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -4,6 +4,8 @@ use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::result;
 
+#[cfg(target_env = "sgx")]
+use std::os::fortanix_sgx as os;
 #[cfg(any(target_os = "hermit", target_os = "redox", unix))]
 use std::os::unix as os;
 #[cfg(any(target_env = "wasi", target_os = "wasi"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,8 @@
 // https://github.com/rust-lang/docs.rs/issues/147#issuecomment-389544407
 // https://github.com/dylni/os_str_bytes/issues/2
 #![cfg_attr(os_str_bytes_docs_rs, feature(doc_cfg))]
+// Nightly is also currently required for the SGX platform
+#![cfg_attr(target_env = "sgx", feature(sgx_platform))]
 #![forbid(unsafe_code)]
 #![warn(unused_results)]
 


### PR DESCRIPTION
Supports the `x86_64-fortanix-unknown-sgx` target by using `std::os::fortanix_sgx`.