### PR TITLE
Support SOLID targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ The minimum supported Rust toolchain version depends on the platform:
         <td>nightly (<a href="https://doc.rust-lang.org/unstable-book/library-features/sgx-platform.html"><code>sgx_platform</code></a>)</td>
     </tr>
     <tr>
+        <td>SOLID</td>
+        <td><code>*-kmc-solid_*</code></td>
+        <td>1.57.0</td>
+    </tr>
+    <tr>
         <td>Unix</td>
         <td>Unix</td>
         <td>1.52.0</td>

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -6,6 +6,8 @@ use std::result;
 
 #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
 use std::os::fortanix_sgx as os;
+#[cfg(target_os = "solid_asp3")]
+use std::os::solid as os;
 #[cfg(any(target_os = "hermit", unix))]
 use std::os::unix as os;
 #[cfg(target_os = "wasi")]


### PR DESCRIPTION
Adds support for [the SOLID targets](https://doc.rust-lang.org/1.61.0/rustc/platform-support/kmc-solid.html) (`*-kmc-solid_*`) by using `std::os::solid`.
