### PR TITLE
os: add support for xous

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -12,6 +12,8 @@ use std::os::solid as os;
 use std::os::unix as os;
 #[cfg(target_os = "wasi")]
 use std::os::wasi as os;
+#[cfg(target_os = "xous")]
+use std::os::xous as os;
 
 use os::ffi::OsStrExt;
 use os::ffi::OsStringExt;


### PR DESCRIPTION
Add support for riscv32imac-unknown-xous-elf.

The entire system is based on UTF-8. The `OsStrExt` and `OsStringExt` modules provide identical implementations to unix and wasi.