### PR TITLE
rename directory of HermitCore's OS related files

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -6,9 +6,11 @@ use std::result;
 
 #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
 use std::os::fortanix_sgx as os;
+#[cfg(target_os = "hermit")]
+use std::os::hermit as os;
 #[cfg(target_os = "solid_asp3")]
 use std::os::solid as os;
-#[cfg(any(target_os = "hermit", unix))]
+#[cfg(unix)]
 use std::os::unix as os;
 #[cfg(target_os = "wasi")]
 use std::os::wasi as os;


### PR DESCRIPTION
The latest version of libstd provides a new location of the HermitCore's OS related files. The kernel depends on the latest version of libstd. Consequently, this PR renames the location.