### PR TITLE
Add WASI feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
         target: [wasm32-unknown-unknown, wasm32-wasip1, x86_64-unknown-redox]
         version: [1.78.0, stable, beta, nightly]
         include:
+        - target: wasm32-wasip2
+          version: nightly
         - target: x86_64-fortanix-unknown-sgx
           version: nightly
         - target: x86_64-unknown-uefi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,10 @@
     feature(sgx_platform)
 )]
 #![cfg_attr(target_os = "uefi", feature(uefi_std))]
+#![cfg_attr(
+    all(target_os = "wasi", target_env = "p2"),
+    feature(wasip2)
+)]
 #![warn(unused_results)]
 
 use std::borrow::Cow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,10 +203,7 @@
     feature(sgx_platform)
 )]
 #![cfg_attr(target_os = "uefi", feature(uefi_std))]
-#![cfg_attr(
-    all(target_os = "wasi", target_env = "p2"),
-    feature(wasip2)
-)]
+#![cfg_attr(all(target_os = "wasi", target_env = "p2"), feature(wasip2))]
 #![warn(unused_results)]
 
 use std::borrow::Cow;


### PR DESCRIPTION
Opt in to feature(wasip2) when we're building for the `wasip2` target. This feels a little redundant but the compiler demands it.

Not tested yet.